### PR TITLE
feat: add tasks API route

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import {
+  createTaskSchema,
+  taskQuerySchema,
+  validateRequestBody,
+  validateQuery
+} from '@/lib/validation';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const validatedQuery = validateQuery(taskQuerySchema, searchParams);
+
+    let whereClause: any = { couple_id: validatedQuery.coupleId };
+
+    if (validatedQuery.status && validatedQuery.status !== 'all') {
+      whereClause.status = validatedQuery.status;
+    }
+
+    if (validatedQuery.assignedTo && validatedQuery.assignedTo !== 'all') {
+      whereClause.assigned_to = validatedQuery.assignedTo;
+    }
+
+    if (validatedQuery.category && validatedQuery.category !== 'all') {
+      whereClause.category = validatedQuery.category;
+    }
+
+    const tasks = await db.task.findMany({
+      where: whereClause,
+      orderBy: [
+        { due_at: 'asc' },
+        { created_at: 'desc' }
+      ],
+    });
+
+    const transformedTasks = tasks.map(task => ({
+      ...task,
+      ai_reasoning: task.ai_reasoning ? JSON.parse(task.ai_reasoning as string) : null,
+    }));
+
+    return NextResponse.json(transformedTasks);
+  } catch (error) {
+    console.error('Error fetching tasks:', error);
+
+    if (error instanceof Error && error.message.includes('validation failed')) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const validatedData = validateRequestBody(createTaskSchema, body);
+
+    const task = await db.task.create({
+      data: {
+        couple_id: validatedData.coupleId,
+        title: validatedData.title,
+        description: validatedData.description,
+        assigned_to: validatedData.assignedTo,
+        category: validatedData.category,
+        status: validatedData.status || 'PENDING',
+        ai_reasoning: validatedData.aiReasoning ? JSON.stringify(validatedData.aiReasoning) : undefined,
+        due_at: validatedData.dueAt ? new Date(validatedData.dueAt) : null,
+      },
+    });
+
+    const transformedTask = {
+      ...task,
+      ai_reasoning: task.ai_reasoning ? JSON.parse(task.ai_reasoning as string) : null,
+    };
+
+    return NextResponse.json(transformedTask, { status: 201 });
+  } catch (error) {
+    console.error('Error creating task:', error);
+
+    if (error instanceof Error && error.message.includes('Validation failed')) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -78,6 +78,32 @@ export const updateMemorySchema = createMemorySchema.partial().extend({
   id: z.string().min(1, 'ID is required')
 });
 
+// Task schemas
+const taskStatusSchema = z.enum(['PENDING', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED']);
+const taskCategorySchema = z.enum(['DAILY', 'WEEKLY', 'MONTHLY', 'SEASONAL']);
+
+export const createTaskSchema = z.object({
+  coupleId: coupleIdSchema,
+  title: z.string().min(1, 'Title is required').max(255, 'Title too long'),
+  description: z.string().max(1000, 'Description too long').optional(),
+  assignedTo: z.enum(['partner_a', 'partner_b', 'both']),
+  category: taskCategorySchema,
+  status: taskStatusSchema.optional(),
+  dueAt: optionalDateSchema,
+  aiReasoning: z.any().optional()
+});
+
+export const updateTaskSchema = createTaskSchema.partial().extend({
+  id: z.string().min(1, 'ID is required')
+});
+
+export const taskQuerySchema = z.object({
+  coupleId: coupleIdSchema,
+  status: taskStatusSchema.or(z.literal('all')).optional(),
+  assignedTo: z.string().optional(),
+  category: taskCategorySchema.or(z.literal('all')).optional(),
+});
+
 // Recipe schemas
 const difficultySchema = z.enum(['easy', 'medium', 'hard']);
 const cuisineSchema = z.enum(['italian', 'mexican', 'indian', 'chinese', 'american', 'mediterranean', 'french', 'thai', 'japanese', 'other']);


### PR DESCRIPTION
## Summary
- add task-related validation schemas
- implement REST endpoints for tasks

## Testing
- `CI=1 npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5f80d75b0832a98c6364f5d729258